### PR TITLE
Fix Deprecated Github Commands

### DIFF
--- a/.github/workflows/generate_csv.yaml
+++ b/.github/workflows/generate_csv.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate release tag
         id: date
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%d_%H-%M-%S')"
+        run: echo "timestamp=$(date +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_OUTPUT
 
       # Using a commit hash due to https://github.com/softprops/action-gh-release/issues/222#issuecomment-1118176601
       - name: Create GitHub release


### PR DESCRIPTION
This is a best attempt pull request to upgrade outdated actions. Failure to upgrade may mean your actions stop working on June 1st, 2023. We only targeted one branch (usually development) and you can deploy those changes to other branches. Some workflows may need extra tweaking to work. Feel free to contact Jamie Visker if you have questions or want another branch targeted.